### PR TITLE
Update post

### DIFF
--- a/content/creating-an-audio-plugin-with-rust-vst.md
+++ b/content/creating-an-audio-plugin-with-rust-vst.md
@@ -175,7 +175,7 @@ If you don't have a VST host, go ahead and use the aptly named [VST host](http:/
 Believe it or not, we already have something we can compile and load into a host.  Go ahead and build your project.
 
 ```
-cargo build
+cargo build --release
 ```
 
 If all goes well, you should have a successful build.  A file named `whisper.dll` should be present in your `target/debug` directory.  This is our VST file.


### PR DESCRIPTION
Use `cargo build --release` instead of `cargo build` (the latter produces an unoptimized binary). I think this change is important, since I have encountered lots of beginners confused by Rusts horrible performance (because they don't know they have to use the `--release` flag)